### PR TITLE
fix: oauth2 audience not sent

### DIFF
--- a/plugins/auth-oauth2/src/getAccessToken.ts
+++ b/plugins/auth-oauth2/src/getAccessToken.ts
@@ -41,7 +41,7 @@ export async function getAccessToken(
   };
 
   if (scope) httpRequest.body!.form.push({ name: 'scope', value: scope });
-  if (scope) httpRequest.body!.form.push({ name: 'audience', value: audience });
+  if (audience) httpRequest.body!.form.push({ name: 'audience', value: audience });
 
   if (credentialsInBody) {
     httpRequest.body!.form.push({ name: 'client_id', value: clientId });


### PR DESCRIPTION
The OAuth2 audience was only getting sent if scope was set. I think this is unintentional, since scope is optional.